### PR TITLE
Upgrade to intl-format-cache@2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "intl": "^0.1.4",
-    "intl-format-cache": "2.0.4",
+    "intl-format-cache": "2.0.5",
     "intl-messageformat": "1.1.0",
     "intl-relativeformat": "1.1.0"
   },


### PR DESCRIPTION
Fixes issue with Chrome Canary: https://github.com/yahoo/intl-format-cache/issues/9